### PR TITLE
Update karma-jasmine dep version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "",
   "dependencies": {
-  	"karma-jasmine": "~0.2"
+  	"karma-jasmine": "~0.3"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
Note: since `karma-jasmine: "~0.3"`, the package does not embed its own jasmine (https://github.com/karma-runner/karma-jasmine), but rely on `jasmine-core: "~2.3.4"` (https://www.npmjs.com/package/jasmine-core) by the Jasmine Team.
Upgrading package.json worked fine for me so far, no regression noticed.
