### PR TITLE
Change module name to 'kjhtml' to not clash with karma-html-reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install karma-jasmine-html-reporter --save-dev
 module.exports = function(config) {
   config.set({
 
-    reporters: ['html']
+    reporters: ['kjhtml']
 
   });
 };
@@ -40,5 +40,5 @@ module.exports = function(config) {
 
 You can pass list of reporters as a CLI argument too:
 ```bash
-karma start --reporters html
+karma start --reporters kjhtml
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -14,5 +14,5 @@ var initReporter = function(files,  baseReporterDecorator) {
 initReporter.$inject = ['config.files',  'baseReporterDecorator'];
 
 module.exports = {
-  'reporter:html': ['type', initReporter]
+  'reporter:kjhtml': ['type', initReporter]
 };


### PR DESCRIPTION
My request is to simply change the module name so that it can be used alongside the `karma-html-reporter` module.  Currently, both of these modules have the same name -- `'html'` -- and, as a result, clash when you try to include both of them in the `reporters` section of the karma configuration file.  

I have read that other developers would like the option of using both.  I use either one in the other from project to project, but I don't think anyone should be restricted.
