### PR TITLE
fix for "Duplicate Console Log Entries"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ var initReporter = function(files,  baseReporterDecorator) {
 
   baseReporterDecorator(this);
 
+  this.specFailure = () => '';
+
   files.forEach(function(file, index) {
     if (JASMINE_CORE_PATTERN.test(file.pattern)) {
       jasmineCoreIndex = index;


### PR DESCRIPTION
This is a fix for #11. This is mainly a problem when there is **more than one reporter being used simultaneously**. This is kind of a heavy-handed approach because it makes it impossible to ever get output to the terminal. A better approach would be to create a mechanism for specifying options to this plugin so that people using it could specify in `karma.conf.js` whether or not they wanted output to the terminal.