### PR TITLE
Make xit behave the same way as xdescribe

### DIFF
--- a/src/css/jasmine.css
+++ b/src/css/jasmine.css
@@ -18,8 +18,8 @@ body { background-color: #eeeeee; padding: 0; margin: 5px; overflow-y: scroll; }
 .html-reporter .symbol-summary li.failed:before { color: #b03911; content: "x"; font-weight: bold; margin-left: -1px; }
 .html-reporter .symbol-summary li.disabled { font-size: 14px; }
 .html-reporter .symbol-summary li.disabled:before { color: #bababa; content: "\02022"; }
-.html-reporter .symbol-summary li.pending { line-height: 17px; }
-.html-reporter .symbol-summary li.pending:before { color: #ba9d37; content: "*"; }
+.html-reporter .symbol-summary li.pending { font-size: 14px; }
+.html-reporter .symbol-summary li.pending:before { color: #bababa; content: "\02022"; }
 .html-reporter .exceptions { color: #fff; float: right; margin-top: 5px; margin-right: 5px; }
 .html-reporter .bar { line-height: 28px; font-size: 14px; display: block; color: #eee; }
 .html-reporter .bar.failed { background-color: #b03911; }
@@ -43,7 +43,7 @@ body { background-color: #eeeeee; padding: 0; margin: 5px; overflow-y: scroll; }
 .html-reporter .summary ul.suite { margin-top: 7px; margin-bottom: 7px; }
 .html-reporter .summary li.passed a { color: #5e7d00; }
 .html-reporter .summary li.failed a { color: #b03911; }
-.html-reporter .summary li.pending a { color: #ba9d37; }
+.html-reporter .summary li.pending a { color: #bababa; }
 .html-reporter .description + .suite { margin-top: 0; }
 .html-reporter .suite { margin-top: 14px; }
 .html-reporter .suite a { color: #333333; }

--- a/src/lib/html.jasmine.reporter.js
+++ b/src/lib/html.jasmine.reporter.js
@@ -96,7 +96,12 @@ jasmineRequire.HtmlReporter = function(j$) {
 
         var failures = [];
         this.specDone = function(result) {
-            if (result.status != "disabled") {
+            var excluded = (
+                result.status === "pending"
+                && result.pendingReason
+                && /xit/.test(result.pendingReason)
+            );
+            if (!excluded && result.status != "disabled") {
                 specsExecuted++;
             }
 
@@ -126,10 +131,6 @@ jasmineRequire.HtmlReporter = function(j$) {
                 }
 
                 failures.push(failure);
-            }
-
-            if (result.status == "pending") {
-                pendingSpecCount++;
             }
         };
 
@@ -162,7 +163,9 @@ jasmineRequire.HtmlReporter = function(j$) {
                 );
             }
             var statusBarMessage = "" + pluralize("spec", specsExecuted) + ", " + pluralize("failure", failureCount);
-            if (pendingSpecCount) { statusBarMessage += ", " + pluralize("pending spec", pendingSpecCount); }
+
+            var excludedSpecCount = (totalSpecsDefined - specsExecuted);
+            if (excludedSpecCount) { statusBarMessage += ", " + pluralize("excluded spec", excludedSpecCount); }
 
             var statusBarClassName = "bar " + ((failureCount > 0) ? "failed" : "passed");
             alert.appendChild(createDom("span", {className: statusBarClassName}, statusBarMessage));


### PR DESCRIPTION
Addresses issue #29 .

Report summary now looks like this:
![report](https://user-images.githubusercontent.com/12819256/35343951-e3b50f46-00f9-11e8-98ce-ade43cf43c84.png)
